### PR TITLE
Outlier search in run list

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,18 @@ Activate the environment to start the analysis:
 ```bash
 conda activate v2dl5
 ```
+
+## Run list generator
+
+The tool `runlist.py` allows to generate a list of runs for a given observation time and zenith angle.
+It generates a lot of printout which should be used to fine tune the run selection.
+
+Example:
+
+```bash
+
+python v2dl5/scripts/generate_runlist.py \
+    --obs_table ../../../VTS/DL3/v490/dl3_pointlike_moderate2tel/obs-index.fits.gz \
+    --config examples/run_selection.yml \
+   --output_dir my_output_dir
+```

--- a/examples/run_selection.yml
+++ b/examples/run_selection.yml
@@ -22,8 +22,11 @@ dqm:
 
   ontime_min: 3 min
 
-  # TODO
-  # l3_rate_min: (epoch, rate)
+  l3_rate_min:
+    V4: 10 Hz
+    V5: 10 Hz
+    V6: 10 Hz
+    V6_redHV: 10 Hz
 
 
 atmosphere:

--- a/examples/run_selection.yml
+++ b/examples/run_selection.yml
@@ -22,6 +22,10 @@ dqm:
 
   ontime_min: 3 min
 
+  # TODO
+  # l3_rate_min: (epoch, rate)
+
+
 atmosphere:
 
   weather: ["A", "B", "C"]

--- a/examples/run_selection.yml
+++ b/examples/run_selection.yml
@@ -2,7 +2,8 @@
 # Configuration for runlist generator
 
 observations:
-  obs_cone_radius: 1.5 deg
+  obs_cone_radius_min: 0.25 deg
+  obs_cone_radius_max: 1.5 deg
 
 on_region:
   target: "LS I +61 303"
@@ -27,7 +28,6 @@ dqm:
     V5: 10 Hz
     V6: 10 Hz
     V6_redHV: 10 Hz
-
 
 atmosphere:
 

--- a/v2dl5/run_lists.py
+++ b/v2dl5/run_lists.py
@@ -40,9 +40,7 @@ def _read_observation_table(obs_table_file_name):
     """
 
     obs_table = astropy.table.Table.read(obs_table_file_name)
-    # TODO - check if necessary
     obs_table["DQMSTAT"].fill_value = "unknown"
-
     return obs_table.filled()
 
 

--- a/v2dl5/scripts/generate_runlist.py
+++ b/v2dl5/scripts/generate_runlist.py
@@ -11,6 +11,10 @@ Generates three output files:
 2. A detailed printout of the observation table for all runs which satisfy the criteria.
 3. A detailed printout of the observation table for all runs which do not satisfy the criteria.
 
+Applies a simple outlier detection based on mean, median, standard, and absolute deviation of L3Rate
+and FIR1. This should be used as indications for further investigation, not as hard cuts to remove
+runs.
+
 Example:
 
 .. code-block:: console
@@ -24,6 +28,7 @@ Example:
 
 import argparse
 import logging
+from pathlib import Path
 
 import v2dl5.configuration
 import v2dl5.run_lists
@@ -67,11 +72,11 @@ def main():
 
     """
     logging.root.setLevel(logging.INFO)
-
     args_dict = v2dl5.configuration.configuration(args=_parse(), generate_dqm_run_list=True)
+    output_path = Path(args_dict["output_dir"])
+    output_path.mkdir(parents=True, exist_ok=True)
 
     sky_regions = v2dl5.sky_regions.SkyRegions(args_dict=args_dict)
-
     v2dl5.run_lists.generate_run_list(args_dict=args_dict, target=sky_regions.target)
 
 

--- a/v2dl5/scripts/generate_runlist.py
+++ b/v2dl5/scripts/generate_runlist.py
@@ -2,7 +2,7 @@
 """
 Generate a run list for a given sky region or a given target.
 
-Reads in a yaml file (see example `examples/run_selection.yaml`)
+Reads in a configuration yaml file (see example `examples/run_selection.yaml`)
 with criteria for selecting runs.
 
 Generates three output files:


### PR DESCRIPTION
This PR improves the run selection using different absolute or relative criteria.

Remaining todos:

- [ ] possibility to use all runs for determination of averages / medians / widths of the distributions (check if this requires some scaling to account for zenith angle dependencies of e.g. rates
- [x] improved printing and reporting of runs removed to log